### PR TITLE
asadiqbal08/Footer issues fixes

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -12,14 +12,18 @@
 %>
 <%
   platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
-  footer = get_footer(is_secure=True)
+  footer = get_footer(is_secure=request.is_secure())
   footer['copyright'] = _(u"\u00A9 {org_name}.  All rights reserved except where noted.").format(org_name=platform_name)
+  marketing_urls = configuration_helpers.get_value(
+        'MKTG_URLS',
+        settings.MKTG_URLS
+    )
   for idx, link_data in enumerate(footer["navigation_links"]):
     if link_data["name"] == "help-center":
       link_data["title"] = _("Support Center")
       footer["navigation_links"][idx] = link_data
     elif link_data["name"] == "contact":
-      contact_url = settings.MKTG_URLS.get("CONTACT", None)
+      contact_url = marketing_urls.get("CONTACT", None)
       if contact_url:
         link_data["url"] = contact_url
         footer["navigation_links"][idx] = link_data


### PR DESCRIPTION
fixes: #17 

### acceptance criteria:

- [ ] "About" should link to the Marketing site / about-us (on RC, that would be https://rc.mitxonline.mit.edu/about-us/) 
- [ ] "Support Center" should link to https://mitx-micromasters.zendesk.com/hc (until we have an MITx Online help center) 
- [ ] "Contact Us" should link to https://mitx-micromasters.zendesk.com/hc/en-us/requests/new (until we have an MITx Online help center) 
- [ ] Terms of Service and Honor code should be separate links. Terms of service links to [`/terms-of-service` on the marketing site](https://rc.mitxonline.mit.edu/terms-of-service). Honor code links to [`/honor-code` on the marketing site](https://rc.mitxonline.mit.edu/honor-code/)

@pdpinch @blarghmatey kindly take a look over the images. For the URL, what I did, I setup the `site-configurations` for the marketing URLs as below: 

```
{
  "ENABLE_MKTG_SITE": true,
  "COURSE_CATALOG_API_URL": "http://edx.devstack.discovery:18381/api/v1/",
  "platform_name": "Mitx Online",
  "FOOTER_ORGANIZATION_IMAGE": "images/logo.png",
  "PLATFORM_DESCRIPTION": "Mitx Online",
  "MKTG_URLS": {
    "ABOUT": "/about-us",
    "CONTACT": "http://mitx-micromasters.zendesk.com/hc/en-us/requests/new",
    "TOS": "/terms-of-service",
    "HONOR": "/honor"
  }
}
```

I have to comment out those that are not required to work on my local machine it properly.
Aslo, we need to set the `"SUPPORT_SITE_LINK": "https://mitx-micromasters.zendesk.com/hc",` over the QA instance in order to show the `Support Center` in footer. 

### SCREENSHOTS

<img width="672" alt="Screen Shot 2021-08-24 at 4 00 06 PM" src="https://user-images.githubusercontent.com/7334669/130612734-bd81f84f-a33e-4c58-9433-8687d8b327c5.png">

<img width="786" alt="Screen Shot 2021-08-24 at 3 19 05 PM" src="https://user-images.githubusercontent.com/7334669/130612742-026ceb44-eca9-49ba-a298-ce4dd2011e4f.png">

<img width="1437" alt="Screen Shot 2021-08-24 at 12 07 29 PM" src="https://user-images.githubusercontent.com/7334669/130612749-09c5b7a0-294e-409d-8913-f5c721bcdd7a.png">

<img width="1213" alt="Screen Shot 2021-08-24 at 5 02 53 PM" src="https://user-images.githubusercontent.com/7334669/130613082-34c55e62-7285-4fca-b3ad-a739f33e7713.png">

![Screen Shot 2021-08-24 at 5 21 24 PM](https://user-images.githubusercontent.com/7334669/130615781-1e946111-2827-4157-b27d-0de070a37299.jpg)


