### PR TITLE
fix: added tweak to redirect to marketing site's home page when logout from edX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Mac OS X
 .DS_Store
+
+# ignore generated assets
+lms/static/css
+cms/static/css

--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -51,7 +51,7 @@
         context. As, we cannot access the MARKETING_SITE_BASE_URL from settings so, to mimic the behaviour
         of redirect to the marketing site we are using tpa_logout_url replacing the /logout/ part in case target is /.
     {% endcomment %}
-    <div id="iframeContainer" style="visibility: hidden" data-redirect-url="{% if target == '/' %}{{tpa_logout_url|slice:':-8'}}{% else %}{{ target }}{% endif %}">
+    <div id="iframeContainer" style="visibility: hidden" data-redirect-url="{% if tpa_logout_url and target == '/' %}{{tpa_logout_url|slice:':-8'}}{% else %}{{ target }}{% endif %}">
         {% for uri in logout_uris %}
             <iframe src="{{ uri }}"></iframe>
         {% endfor %}

--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -1,0 +1,60 @@
+{% extends "main_django.html" %}
+{% load i18n static %}
+{% load django_markup %}
+
+{% block title %}{% trans "Signed Out" as tmsg %}{{ tmsg | force_escape }} | {{ block.super }}{% endblock %}
+
+{% block body %}
+    {% if show_tpa_logout_link %}
+        <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+        <p style="text-align: center; margin-bottom: 20px;">
+            {% blocktrans trimmed asvar sso_signout_msg %}
+              {start_anchor}Click here{end_anchor} to delete your single signed on (SSO) session.
+            {% endblocktrans %}
+            {% interpolate_html sso_signout_msg start_anchor='<a href="'|add:tpa_logout_url|add:'">'|safe end_anchor='</a>'|safe %}
+        </p>
+
+    {% else %}
+        {% if enterprise_target %}
+            {% comment %}
+                For enterprise SSO flow we intentionally drop learner's session.
+                We are showing this signin message instead of logout message
+                to avoid any confusion for learner in that case.
+            {% endcomment %}
+            <h1>{% trans "We are signing you in." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+            <p style="text-align: center; margin-bottom: 20px;">
+                {% filter force_escape %}
+                {% blocktrans %}
+                  This may take a minute. If you are not redirected, go to the home page.
+                {% endblocktrans %}
+                {% endfilter %}
+            </p>
+        {% else %}
+            <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+            <p style="text-align: center; margin-bottom: 20px;">
+                {% blocktrans trimmed asvar signout_msg1 %}
+                  If you are not redirected within 5 seconds, {start_anchor}click here to go to the home page{end_anchor}.
+                {% endblocktrans %}
+                {% interpolate_html signout_msg1 start_anchor='<a href="'|add:target|add:'">'|safe end_anchor='</a>'|safe %}
+            </p>
+        {% endif %}
+
+        <script type="text/javascript" src="{% static 'js/jquery.allLoaded.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/logout.js' %}"></script>
+    {% endif %}
+
+    {% comment %}
+        In the django templates of the theme we can only use the values passed in the template through
+        context. As, we cannot access the MARKETING_SITE_BASE_URL from settings so, to mimic the behaviour
+        of redirect to the marketing site we are using tpa_logout_url replacing the /logout/ part in case target is /.
+    {% endcomment %}
+    <div id="iframeContainer" style="visibility: hidden" data-redirect-url="{% if target == '/' %}{{tpa_logout_url|slice:':-8'}}{% else %}{{ target }}{% endif %}">
+        {% for uri in logout_uris %}
+            <iframe src="{{ uri }}"></iframe>
+        {% endfor %}
+    </div>
+
+{% endblock body %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
(Related to the Point#2 in [this comment](https://github.com/mitodl/mitxonline/issues/102#issuecomment-904629373))

#### What's this PR do?
- It overrides the logout.html template from edX LMS
- It adds a small tweak in `tpa_logout_url` and uses it to redirect the user to the marketing website -- This tweak is done because the `logout.html` is a django template and we would not be able to import/use the `MARKETING_SITE_BASE_URL` from settings
- Since `tpa_logout_url` comes from the `logout_url` that we add to our auth provider for MITx Online and as its already a part of the context so we can remove `/logout/` part from it and use the remaining as a redirect URL.

#### How should this be manually tested?
- It's necessary that you've configured edX auth with MITxOnline through the steps mentioned [here](https://github.com/mitodl/mitxonline)
- Make sure to add `logout_url` value when you add provider configuration in edX.
- Apply this theme
- Now login to the edX and click logout, You should be redirected to the marketing website (In our case it will be `tpa_logout_url` without `/logout/`)
- Make sure that you've been logged out from both edX and MITxOnline.


#### Any background context you want to provide?
- This PR is part of a 2-way redirection after in the logout:

 1) You're logged into the marketing website e.g. (https://rc.mitxonline.mit.edu/) and when you click logout the app logs out the user from MITxOnline and then calls edX's logout with a redirect URL param e.g. (https://courses-qa.mitxonline.mit.edu/logout?redirect_url=https%3A%2F%2Frc.mitxonline.mit.edu) So , edX gets logged out and reditects us back to the home page of Marketing website(`https://rc.mitxonline.mit.edu/`) - This part was done after whitelisting the marketing app domain inside edX.

2) In this case you are logged in and you're on edX's home page e.g. `https://courses-qa.mitxonline.mit.edu` and you click logout so in this case edX calls it's own `/logout` without any redirect param and it calls `https://rc.mitxonline.mit.edu/logout` to log the user out of the IDP. Notice that edX does not add any redirects in it's logout in this case because it expects the user to be back on the home page of edX. So to redirect the user to the home page of MITxOnline we have added this tweak in the theme.
