### PR TITLE
asadiqbal08/Update ACE Templates

### DIFF
--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -61,12 +61,12 @@
                 <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
                     <tr>
                         <td width="70">
-                            <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="https://courses.xpro.mit.edu/static/mitxpro-theme/images/logo.png" width="130"
+                            <a href="{% with_link_tracking site_configuration_values.HOMEPAGE_URL %}"><img
+                                    src="https://rc.mitxonline.mit.edu/static/images/mitx-online-logo.png" width="130"
                                     height="40" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
-                            <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>
+                            <a class="login" href="{% with_link_tracking site_configuration_values.SIGNIN_URL %}" style="color: #005686;">{%  trans "Sign In" %}</a>
                         </td>
                     </tr>
                 </table>
@@ -171,7 +171,7 @@
                     <tr>
                         <!-- COPYRIGHT -->
                         <td>
-                            &copy; {% now "Y" %} MIT xPRO, {% trans "All rights reserved" %}.<br/>
+                            &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" %}.<br/>
                             <br/>
                             {% trans "Our mailing address is" %}:<br/>
                             MIT Open Learning<br/>600 Technology Square, 2nd Floor<br/>Cambridge, MA 02139<br/>USA

--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking site_configuration_values.HOMEPAGE_URL %}"><img
-                                    src="https://mitxonline.mit.edu/static/images/mitx-online-logo.png" width="135"
+                                    src="https://mitxonline.mit.edu/static/images/mitx-online-logo.png" width="auto"
                                     height="40" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">

--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking site_configuration_values.HOMEPAGE_URL %}"><img
-                                    src="https://rc.mitxonline.mit.edu/static/images/mitx-online-logo.png" width="130"
+                                    src="https://mitxonline.mit.edu/static/images/mitx-online-logo.png" width="135"
                                     height="40" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -1,0 +1,38 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% filter force_escape %}
+                {% blocktrans %}
+                    You have been enrolled in {{ course_name }}
+                {% endblocktrans %}
+                {% endfilter %}
+            </h1>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+
+            {% filter force_escape %}
+                {% blocktrans asvar course_cta_text %}Access the Course Materials Now{% endblocktrans %}
+            {% endfilter %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}


### PR DESCRIPTION
fixes: #12 


### How to test ?
- Apply the mitxonline theme of this branch over the platform instance.
- Visit the membership tab under instructor in LMS. 
- Add up some email(s) for sending Edx-Ace enrollment emails. 
- Emails templates are server from `/edx/src/` directory so the reviewer can open those HTML files in order to verify the below points.

### What to test ?

- [ ] MITx Online logo (Logo point out to MitxOnline instead of MitxPro)
- [ ] Link logo to MITx Online dashboard (on RC, this is https://rc.mitxonline.mit.edu/dashboard) 
- [ ] Sign in link should go to MITx Online sign in page (on RC, this is https://rc.mitxonline.mit.edu/signin)
- [ ] "Access the Course Materials Now" button should work
- [ ] Mailing address should be populated and not display "SET-ME-PLEASE" (this is probably an environment setting) 
- [ ] Copyright string should use platform name, or be hardcoded to "MITx Online" 

Regarding to this point below, on the local devstack, edx ace emails are displayed over the terminal console, where it will show up the platform name. It seems me mostly related to configurations and can be test once it is deployed over QA instance of edx-platform. 
- [ ] Return address should be set to "MITx Online" <mitxonline-support@mit.edu> (I'm pretty sure this is an environment setting; see https://github.com/mitodl/ol-infrastructure/issues/327) 

### Site Configurations
I am using these possible configurations for testing such as `homepage_url` OR  `singin_url`

```
{
  "ENABLE_MKTG_SITE": true,
  "COURSE_CATALOG_API_URL": "http://edx.devstack.discovery:18381/api/v1/",
  "PLATFORM_NAME": "Mitx Online",
  "FOOTER_ORGANIZATION_IMAGE": "images/logo.png",
  "SIGNIN_URL": "/signin",
  "HOMEPAGE_URL": "/dashboard",
  "MKTG_URLS": {
    "ABOUT": "/about-us",
    "CONTACT": "http://mitx-micromasters.zendesk.com/hc/en-us/requests/new",
    "TOS": "/terms-of-service",
    "HONOR": "/honor"
  }
}
```



<img width="1440" alt="Screen Shot 2021-09-27 at 2 56 46 PM" src="https://user-images.githubusercontent.com/7334669/134887521-04d9e22b-9b91-4949-b416-0668fff5fcef.png">

