### PR TITLE
fix: 500 errors for sysadmin reverse when edx-sysadmin isn't installed

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -14,7 +14,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 <%
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing
-  show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
+
+  try:
+    from edx_sysadmin.utils.utils import show_sysadmin_dashboard
+    sysadmin_dashboard = show_sysadmin_dashboard(user)
+  except:
+    sysadmin_dashboard = None
+
   self.real_user = getattr(user, 'real_user', user)
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
@@ -69,10 +75,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
           </a>
       </div>
     % endif
-    % if show_sysadmin_dashboard:
+    % if sysadmin_dashboard:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
         ## Translators: This is short for "System administration".
-        <a class="tab-nav-link" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+        <a class="tab-nav-link" href="${reverse('sysadmin:sysadmin')}">${_("Sysadmin")}</a>
       </div>
     % endif
   </div>


### PR DESCRIPTION
## Related Ticket:
#27 

## What this PR does:
- Fix the logic for showing `edx-sysadmin` tab on LMS
- Fixes the reverse URL for the sysadmin when `edx-sysadmin` is installed

## How to test:
- Setup your edx-platfrom on https://github.com/mitodl/edx-platform/tree/mitx/maple
- Setup the theme and make sure that you can confirm the following
    - You don't see any errors on the dashboard and also don't see `Syadmin` tab (When edx-sysadmin isn't installed)
    - You don't see any errors on dashboard but see `Syadmin` tab (When edx-sysadmin is installed)

## Screenshots
<img width="1388" alt="Screenshot 2021-11-24 at 6 39 21 PM" src="https://user-images.githubusercontent.com/34372316/143249215-839210c6-8629-416a-850b-83122083a447.png">
<img width="1494" alt="Screenshot 2021-11-24 at 6 40 34 PM" src="https://user-images.githubusercontent.com/34372316/143249241-da869af7-4597-4020-993d-8557099e9fcf.png">
