### PR TITLE
fix: update waffle flag usage in theme footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # ignore generated assets
 lms/static/css
 cms/static/css
+
+# Ignore IDE configuration
+.idea/

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -6,7 +6,7 @@ from django.urls import reverse
 from datetime import datetime
 from django.conf import settings
 import pytz
-from cms.djangoapps.contentstore.config.waffle import waffle, ENABLE_ACCESSIBILITY_POLICY_PAGE
+from cms.djangoapps.contentstore.config.waffle import ENABLE_ACCESSIBILITY_POLICY_PAGE
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
@@ -30,7 +30,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 <a data-rel="edx.org" href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
               </li>
             % endif
-            % if waffle().is_enabled(ENABLE_ACCESSIBILITY_POLICY_PAGE):
+            % if ENABLE_ACCESSIBILITY_POLICY_PAGE.is_enabled():
               <li class="nav-item nav-peripheral-aar">
                 <a data-rel="edx.org" href="${reverse('accessibility')}">${_("Accessibility Accommodation Request")}</a>
               </li>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue in the [ol-infrastructure repo](https://github.com/mitodl/ol-infrastructure/issues/new) for any necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/587

#### What's this PR do?
- Fixes the deprecated waffle flag usage in the footer
- Adds IDE config in gitignore

#### How should this be manually tested?
- Setup edx-platform master as of now
- Set the `mitxonline-theme` from this for LMS & CMS and they should load properly

#### Where should the reviewer start?
- Setting up the latest master branch of edX

#### Any background context you want to provide?
The change has to happen because the usage of some waffle flags was deprecated in the edX. [This platform PR](https://github.com/openedx/edx-platform/pull/30330/files#diff-19ccd9b658fde8c786d8eb92cd67dc38c42b424906eb557da01e9220c62e0c7d) migrated the usages for the edX. So i've updated the theme accordingly. 

#### Reviewer Note:
I also looked around the code for other usages of waffle in the code and it looks like this was the only use.

#### Screenshots (if appropriate)
<img width="1670" alt="Screenshot 2022-05-25 at 5 20 05 PM" src="https://user-images.githubusercontent.com/34372316/170261181-15454d20-daaf-42da-b349-ee51012618ee.png">
<img width="1678" alt="Screenshot 2022-05-25 at 5 20 19 PM" src="https://user-images.githubusercontent.com/34372316/170261200-be077d5b-2cff-4fbc-aea3-972fa345285f.png">

