### PR TITLE
feat(footer): update accessibility link title

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -37,6 +37,10 @@
     elif link['name'] == "honor_code":
         link["url"] = urljoin(settings.MARKETING_SITE_BASE_URL, "honor-code")
         footer["legal_links"][item_num] = link
+    elif link['name'] == "accessibility_policy":
+        link["url"] = "https://accessibility.mit.edu/"
+        link["title"] = "Accessibility"
+        footer["legal_links"][item_num] = link
 
 %>
 <%namespace name='static' file='static_content.html'/>
@@ -117,7 +121,11 @@
           <ul>
             % for item_num, link in enumerate(footer['legal_links'], start=1):
               <li class="nav-legal-0${item_num}">
-                <a href="${link['url']}">${link['title']}</a>
+                % if link['name'] == 'accessibility_policy':
+                  <a href="${link['url']}">Accessibility</a>
+                % else:
+                  <a href="${link['url']}">${link['title']}</a>
+                % endif
               </li>
             % endfor
           </ul>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -121,11 +121,7 @@
           <ul>
             % for item_num, link in enumerate(footer['legal_links'], start=1):
               <li class="nav-legal-0${item_num}">
-                % if link['name'] == 'accessibility_policy':
-                  <a href="${link['url']}">Accessibility</a>
-                % else:
                   <a href="${link['url']}">${link['title']}</a>
-                % endif
               </li>
             % endfor
           </ul>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -38,7 +38,6 @@
         link["url"] = urljoin(settings.MARKETING_SITE_BASE_URL, "honor-code")
         footer["legal_links"][item_num] = link
     elif link['name'] == "accessibility_policy":
-        link["url"] = "https://accessibility.mit.edu/"
         link["title"] = "Accessibility"
         footer["legal_links"][item_num] = link
 

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -121,7 +121,7 @@
           <ul>
             % for item_num, link in enumerate(footer['legal_links'], start=1):
               <li class="nav-legal-0${item_num}">
-                  <a href="${link['url']}">${link['title']}</a>
+                <a href="${link['url']}">${link['title']}</a>
               </li>
             % endfor
           </ul>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing (TESTED MANUALLY WITH DEFAULT `lms/templates/footer.html`)
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue in the [ol-infrastructure repo](https://github.com/mitodl/ol-infrastructure/issues/new) for any necessary configuration changes to deployed environments

#### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/759 & https://github.com/mitodl/hq/issues/631

#### What's this PR do?
Updates the title for the Accessibility link in the footer. The default edX title is `Accessibility Policy` but we require `Accessibility`.

#### How should this be manually tested?
I was not able to apply the mitxonline-theme footer. I am not sure why footer.html was not reflecting but the theme was integrated.

- Follow the readme to integrate footer.
- Add the following settings in your `private.py`
```
SUPPORT_SITE_LINK = "https://mitxonline.zendesk.com/hc/"
MKTG_URL_LINK_MAP = {
    "ABOUT": "about",
    "PRIVACY": "privacy",
    "TOS": "tos",
    "HONOR": "honor",
    "ACCESSIBILITY": "accessibility_policy",
    "HELP_CENTER": "help-center"
}
MKTG_URL_OVERRIDES = {
    "PRIVACY": "https://rc.mitxonline.mit.edu/privacy-policy/",
    "TOS": "https://rc.mitxonline.mit.edu/terms-of-service/",
    "ABOUT": "https://rc.mitxonline.mit.edu/about-us/",
    "HONOR": "https://rc.mitxonline.mit.edu/honor-code/",
    "ACCESSIBILTY": "https://accessibility.mit.edu/"
}
```
- If the footer has `Support Center` instead of `Help Center`, it means that the mitxonline-theme footer is working and you should see the updated title for `Accessibility`.
- Otherwise, copy the changes made in this PR to `edx-platform/lms/templates/footer.html` and verify that the title is updated.


#### Any background context you want to provide?
Changes are inspired by https://github.com/mitodl/frontend-component-footer-mitol/pull/9#issuecomment-1448501818

#### Screenshots (if appropriate)
<img width="1750" alt="Screen Shot 2023-03-01 at 1 57 27 PM" src="https://user-images.githubusercontent.com/52656433/222091464-10ac6928-b4aa-4d58-b80d-6e57153366ab.png">

