### PR TITLE
Changing the account profile link to match the pattern used elsewhere

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -61,7 +61,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         </div>
       % endif
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
+          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{self.real_user.username}')}"
              aria-current="${'page' if '/u/' in request.path else 'false'}">
              ${_("Profile")}
           </a>

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -60,12 +60,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
           </a>
         </div>
       % endif
-      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{self.real_user.username}')}"
-             aria-current="${'page' if '/u/' in request.path else 'false'}">
-             ${_("Profile")}
-          </a>
-      </div>
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">


### PR DESCRIPTION
See https://github.com/openedx/edx-platform/commit/0f02c7b3d90292a87f7e6ea15b244a2de18d1a52#diff-7a78dccf2c91b0ec02aaae5989249e06aa23735eeb5e4c971da805cd13888a5c

#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

n/a

#### What's this PR do?

Swaps out the call to `reverse` for a `urljoin` for the user profile link in the navbar. It seems like the route for `learner_profile` has gone away in a recent patch (see above link) so this is failing now.

#### How should this be manually tested?

Go to the learner dashboard in edX. It should work. 

#### Any background context you want to provide?

FWIW I wasn't really able to test this using my devstack copy. It seems to work with that, though. 

Relevant Sentry issue is here: https://mit-office-of-digital-learning.sentry.io/issues/3983725173/?environment=mitxonline-qa&project=5939801&query=is%3Aunresolved&referrer=issue-stream

HQ ticket is here: https://github.com/mitodl/hq/issues/967 (Tobias's notes especially on that)
