### PR TITLE
Removes show_journal_listing block

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -52,14 +52,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
           </a>
         </div>
       % endif
-      % if show_journal_listing:
-        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if reverse('openedx.journals.dashboard') in request.path else ''}tab-nav-link" href="${reverse('openedx.journals.dashboard')}"
-             aria-current="${'page' if reverse('openedx.journals.dashboard') == request.path else 'false'}">
-             ${_("Journals")}
-          </a>
-        </div>
-      % endif
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?

Closes #34 

#### What's this PR do?

Removes a block for the Journals tab in the navbar. (After some grepping through the theme source and the other themes in devstack, I didn't see any other places where this was.) 

#### How should this be manually tested?

Checkout this branch and test going to the dashboard - the Journals tab should not appear.
