### PR TITLE
feat: override proctoring requirements email

### DIFF
--- a/lms/templates/student/edx_ace/proctoringrequirements/email/body.html
+++ b/lms/templates/student/edx_ace/proctoringrequirements/email/body.html
@@ -22,7 +22,7 @@
                 {% endblocktrans %}
                 {% endfilter %}
             </p>
-
+            <br />
             <p style="color: rgba(0,0,0,.75);">
                 {% autoescape off %}
                 {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
@@ -31,7 +31,7 @@
                 {% endblocktrans %}
                 {% endautoescape %}
             </p>
-
+            <br />
             <p style="color: rgba(0,0,0,.75);">
                 {% autoescape off %}
                 {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
@@ -40,7 +40,7 @@
                 {% endblocktrans %}
                 {% endautoescape %}
             </p>
-
+            <br />
             <p style="color: rgba(0,0,0,.75);">
                 {% filter force_escape %}
                 {% blocktrans %}

--- a/lms/templates/student/edx_ace/proctoringrequirements/email/body.html
+++ b/lms/templates/student/edx_ace/proctoringrequirements/email/body.html
@@ -1,0 +1,64 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}
+                    Proctoring requirements for {{ course_name }}
+                {% endblocktrans %}
+                {% endautoescape %}
+            </h1>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}
+                    Hello {{full_name}},
+                {% endblocktrans %}
+                {% endfilter %}
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}
+                    You are enrolled in {{ course_name }} at {{ platform_name }}. This course contains proctored exams.
+                {% endblocktrans %}
+                {% endautoescape %}
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}
+                    Proctored exams are timed exams that you take while proctoring software monitors your computer's desktop, webcam video, and audio. Your course uses {{ proctoring_provider }} software for proctoring.
+                {% endblocktrans %}
+                {% endautoescape %}
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}
+                    Carefully review the system requirements as well as the steps to take a proctored exam in order to ensure that you are prepared.
+                {% endblocktrans %}
+                {% endfilter %}
+            </p>
+
+            <br />
+
+            <p>
+                {% trans "Thank you," as tmsg %}{{ tmsg | force_escape }}
+                <br />
+                {% filter force_escape %}
+                {% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}
+                {% endfilter %}
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue in the [ol-infrastructure repo](https://github.com/mitodl/ol-infrastructure/issues/new) for any necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/725

#### What's this PR do?
- Adds a template override for the proctoring requirements email that's sent when a user enrolls in a course that has proctoring enabled and has proctored exams in it.

#### How should this be manually tested?
There are two options to test this locally.

1. Setup Proctoring backend, Configure eCommerce
    - Follow the instructions on https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/proctored_exams/proctored_enabling.html to enable proctored exams
    - Create a course mode with any of `Professional, Masters, Verified`
    - Setup the ecommerce things for the course https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/index.html
    - Configure email to work locally

2. If you are looking for a simpler way to test the PR (See below)
    - open `openedx/core/djangoapps/enrollments/api.py` and at line#591 add `CourseMode.HONOR` in the `appropriate_modes` list

(Common Steps)
- Setup this theme
- Create a course in the studio
- Create a course mode `Honor` (For testing so that we don't have to enable e-commerce functionality)
- in `Advanced Settings` enable `Enable Proctored Exams`
- In the course content, add a section/sub-section/unit and mark it as `Proctored` through the section grade setting
- Now enroll in this course
- check `/edx/src/ace_messages` directory you should see `*.datestamp.html` files for all the emails being sent.


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
**Before**

<img width="732" alt="image" src="https://github.com/mitodl/mitxonline-theme/assets/34372316/cd218890-8501-42cc-8332-b22a5754c838">


**After**

<img width="609" alt="image" src="https://github.com/mitodl/mitxonline-theme/assets/34372316/1c33a6ae-e97f-4f00-8713-45e9c0454064">
