### PR TITLE
fix: use marketing_link helper instead of MKTG_URLS for contact

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -20,7 +20,7 @@ from openedx.core.djangolib.markup import HTML, Text
       ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {contact_us}.')).format(
         homepage=HTML('<a href="{marketing_site_base_url}">homepage</a>').format(marketing_site_base_url=settings.MARKETING_SITE_BASE_URL),
         contact_us=HTML('<a href="{address}">contact us</a>').format(
-          address=Text(settings.MKTG_URLS.get('CONTACT', None))
+          address=Text(marketing_link('CONTACT'))
         )
       )}
       </p>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -14,16 +14,12 @@
   platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
   footer = get_footer(is_secure=request.is_secure())
   footer['copyright'] = _(u"\u00A9 {org_name}.  All rights reserved except where noted.").format(org_name=platform_name)
-  marketing_urls = configuration_helpers.get_value(
-        'MKTG_URLS',
-        settings.MKTG_URLS
-    )
   for idx, link_data in enumerate(footer["navigation_links"]):
     if link_data["name"] == "help-center":
       link_data["title"] = _("Support Center")
       footer["navigation_links"][idx] = link_data
     elif link_data["name"] == "contact":
-      contact_url = marketing_urls.get("CONTACT", None)
+      contact_url = marketing_link('CONTACT')
       if contact_url:
         link_data["url"] = contact_url
         footer["navigation_links"][idx] = link_data

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
                   homepage=HTML('<a href="{marketing_site_base_url}">homepage</a>').format(marketing_site_base_url=settings.MARKETING_SITE_BASE_URL),
                   email=HTML('<a href="{address}">contact us</a>').format(
-                    address=Text(settings.MKTG_URLS.get('CONTACT', None))
+                    address=Text(marketing_link('CONTACT'))
                   )
                 )}
                 % endif


### PR DESCRIPTION
# What are the relevant tickets?
Partially related to https://github.com/mitodl/hq/issues/3094. 

# Description (What does it do?)
Currently, Our themes use the `CONTACT` URL directly from `MKTG_URLS` dictionary in the settings. This was fine until there were no `MKTG_URL_OVERRIDES`. So, It's possible that a URL exists in `MKTG_URLS` but has been overridden in `MKTG_URL_OVERRIDES` but our theme would never pick it. The open edX helper method takes care of that e.g. it picks the URL from Django admin otherwise `MKTG_URL_OVERRIDES` otherwise `MKTG_URLS` which makes it flexible for us and consistent overall.

<!--- Describe your changes in detail -->
This PR makes our theme use the open edX helper method to get the marketing URLs from the appropriate place.

# How can this be tested?

**Locally:**
- Set DEBUG=False in your private.py or yml
- Apply this theme and open any nonexistent page e.g. localhost:18000/abcd
- Now, See the different combinations:
    - Add a URL for `CONTACT` in `MKTG_URL_OVERRIDES` in Django Admin/Site Configuration and private.py. Also, add a URL for `CONTACT` in `MKTG_URLS` dict.
    - Load 404 page, and I should display the CONTACT value from the Django admin Site. Once verified, remove this value
    - Now load the page again, It should pick the value from `private.py` or `env vars`. Once verified, remove this value
    - Load 404 again, You should now see the `CONTACT` value from `MKTG_URLS` dict in `env vars`.

**Remotely:**
Once deployed, We should see the `contact us` URL as defined in https://github.com/mitodl/ol-infrastructure/pull/1969

# Additional Context

I created another PR in infra https://github.com/mitodl/ol-infrastructure/pull/1969, but when it didn't work I noticed that our themes are using the `MKTG_URLS` instead of the open edX helper.
