### PR TITLE
fix: use LOGO_URL_PNG_FOR_EMAIL instead of LOGO_URL

### DIFF
--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking site_configuration_values.HOMEPAGE_URL %}"><img
-                                    src="{{ site_configuration_values.LOGO_URL }}" width="124.3"
+                                    src="{{ site_configuration_values.LOGO_URL_PNG_FOR_EMAIL }}" width="124.3"
                                     height="33" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the email template to use LOGO_URL_PNG_FOR_EMAIL instead of LOGO_URL.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Setup this theme.
- Set LOGO_URL_PNG_FOR_EMAIL in the admin site configurations.
- Go to the instructor dashboard and send the bulk email. Make sure that the bulk email flag is enabled in the admin to enable the bulk email.
- You should see the URL for the logo you added to the site configurations.
