### PR TITLE
revert: revert to upstream approach to use logo url 

### DIFF
--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking site_configuration_values.HOMEPAGE_URL %}"><img
-                                    src="{{ site_configuration_values.LOGO_URL_PNG_FOR_EMAIL }}" width="124.3"
+                                    src="{{ logo_url }}" width="124.3"
                                     height="33" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">


### PR DESCRIPTION

### What are the relevant tickets?
Following up https://github.com/mitodl/hq/issues/3337#issuecomment-2357798696.

### Description (What does it do?)
This PR reverts to the upstream approach for using the logo URL, as the [upstream PR](https://github.com/openedx/edx-platform/pull/35138) and its [backport](https://github.com/openedx/edx-platform/pull/35378) have been merged.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c514ecbb-d6fd-4f5f-a3f9-78919eab5110)


### How can this be tested?

- Ensure the mitxonline-theme is configured.
- Set LOGO_URL_PNG_FOR_EMAIL in the settings/private.py file.
- Verify that emails sent via batch enrollment use the value set in LOGO_URL_PNG_FOR_EMAIL

### Additional Context
- We might not need to manually set LOGO_URL_PNG_FOR_EMAIL, as it appears to be already set [here](https://github.com/mitodl/ol-infrastructure/blob/main/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl#L358) for all instances.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
