### PR TITLE
fix: Remove reference to maintenance app

### DIFF
--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -51,11 +51,6 @@ full_name = UserProfile.objects.get(user=user).name
         <li class="nav-item nav-account-dashboard">
           <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
         </li>
-        % if GlobalStaff().has_user(user):
-        <li class="nav-item">
-          <a href="${reverse('maintenance:maintenance_index')}">${_("Maintenance")}</a>
-        </li>
-        % endif
         <li class="nav-item nav-account-signout">
           <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
         </li>


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The maintenance app was removed from edx-platform [here](https://github.com/openedx/edx-platform/commit/9274852f2df9e64d3ee7b6de31227c3a5af4440b), causing the reference in the theme to throw errors and fail to load the CMS. This removes that reference.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Try to load the CMS with and without this fix in place.