### PR TITLE
fix: remove digest links

### DIFF
--- a/lms/templates/notifications/digest_footer.html
+++ b/lms/templates/notifications/digest_footer.html
@@ -1,0 +1,32 @@
+<table cellpadding="0" cellspacing="0" style="color:black; font-weight:400; font-size:12px;line-height:20px" width="100%">
+    <tbody>
+        <tr>
+            <td>
+                <table width="100%">
+                    <tbody>
+                        <tr>
+                            <td width="25%" align="left" style="padding: 0">
+                                <img src="{{ logo_url }}" style="width: auto;" height="24" alt="Logo"/></a>
+                            </td>
+                            <td width="75%" align="right" style="padding: 0">
+                                <table>
+                                    <tbody>
+                                        <tr>
+                                            {% for social_name, social_data in social_media.items %}
+                                                <td style="padding: 0">
+                                                    <a href="{{social_data.url}}">
+                                                        <img src="{{social_data.icon}}" style="max-height: 24px; max-width: 24px; margin-left: 0.6rem" alt="{{social_name}}" />
+                                                    </a>
+                                                </td>
+                                            {% endfor %}
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4070

### Description (What does it do?)
This PR removes unaccessible links from the digest email footer

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
