### PR TITLE
fix: add unsubscribe link in digest email

### DIFF
--- a/lms/templates/notifications/digest_footer.html
+++ b/lms/templates/notifications/digest_footer.html
@@ -1,4 +1,4 @@
-<table cellpadding="0" cellspacing="0" style="color:black; font-weight:400; font-size:12px;line-height:20px" width="100%">
+<table cellpadding="0" cellspacing="0" style="color:black; font-weight:400; font-size:0.75rem;line-height:20px" width="100%">
     <tbody>
         <tr>
             <td>
@@ -26,6 +26,21 @@
                         </tr>
                     </tbody>
                 </table>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p style="margin: 1.5rem 0 0 0;">
+                    You are receiving this email because you have subscribed to email digest
+                </p>
+                <p style="margin: 0.625rem 0">
+                    <a href="{{unsubscribe_url}}" rel="noopener noreferrer" target="_blank" style="color: black; margin-left: 1rem">
+                        Unsubscribe from email digest for learning activity
+                    </a>
+                </p>
+                <p>
+                    &copy; {% now "Y" %} {{ platform_name }}. All Rights Reserved.
+                </p>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6354

### Description (What does it do?)
This PR adds the unsubscribe link in daily digest email

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/be03a89d-39ff-4655-97f3-f8d315b42ba1)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
