### PR TITLE
feat: enable Catalog link to redirect to learn marketing app for UAI courses

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -7,6 +7,7 @@ import pytz
 import six
 from urllib.parse import urljoin
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.template import RequestContext
@@ -25,7 +26,13 @@ from common.djangoapps.student.models import CourseEnrollment
 <%
   cert_name_short = settings.CERT_NAME_SHORT
   cert_name_long = settings.CERT_NAME_LONG
-  catalog_link = settings.MARKETING_SITE_BASE_URL
+  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+  request_path = request.get_full_path().lower()
+
+  if any(course_key in request_path for course_key in uai_course_key_formats):
+    catalog_link = settings.MIT_LEARN_BASE_URL
+  else:
+    catalog_link = settings.MARKETING_SITE_BASE_URL
 %>
 
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -30,9 +30,9 @@ from common.djangoapps.student.models import CourseEnrollment
   request_path = request.get_full_path().lower()
 
   if any(course_key in request_path for course_key in uai_course_key_formats):
-    catalog_link = settings.MIT_LEARN_BASE_URL
+    catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MARKETING_SITE_BASE_URL", "#"))
   else:
-    catalog_link = settings.MARKETING_SITE_BASE_URL
+    catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")
 %>
 
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -7,7 +7,6 @@ import pytz
 import six
 from urllib.parse import urljoin
 from datetime import datetime, timedelta
-from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.template import RequestContext
@@ -26,9 +25,7 @@ from common.djangoapps.student.models import CourseEnrollment
 <%
   cert_name_short = settings.CERT_NAME_SHORT
   cert_name_long = settings.CERT_NAME_LONG
-  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
-  request_path = request.get_full_path().lower()
-  catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")
+  catalog_link = settings.MARKETING_SITE_BASE_URL
 %>
 
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -28,11 +28,7 @@ from common.djangoapps.student.models import CourseEnrollment
   cert_name_long = settings.CERT_NAME_LONG
   uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
   request_path = request.get_full_path().lower()
-
-  if any(course_key in request_path for course_key in uai_course_key_formats):
-    catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MARKETING_SITE_BASE_URL", "#"))
-  else:
-    catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")
+  catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")
 %>
 
 

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -26,10 +26,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
-  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+  uai_course_key_format = getattr(settings, "UAI_COURSE_KEY_FORMAT", "")
   request_path = request.get_full_path().lower()
 
-  if any(course_key in request_path for course_key in uai_course_key_formats):
+  if uai_course_key_format and uai_course_key_format in request_path:
     catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MARKETING_SITE_BASE_URL", "#"))
   else:
     catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -30,9 +30,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   request_path = request.get_full_path().lower()
 
   if any(course_key in request_path for course_key in uai_course_key_formats):
-    catalog_link = settings.MIT_LEARN_BASE_URL
+    catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MARKETING_SITE_BASE_URL", "#"))
   else:
-    catalog_link = settings.MARKETING_SITE_BASE_URL
+    catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")
 
   if online_help_token == "instructor":
     help_link = doc_link

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -7,6 +7,7 @@
 <%!
 from urllib.parse import urljoin
 
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -25,7 +26,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
-  catalog_link = settings.MARKETING_SITE_BASE_URL
+  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+  request_path = request.get_full_path().lower()
+
+  if any(course_key in request_path for course_key in uai_course_key_formats):
+    catalog_link = settings.MIT_LEARN_BASE_URL
+  else:
+    catalog_link = settings.MARKETING_SITE_BASE_URL
 
   if online_help_token == "instructor":
     help_link = doc_link

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -22,6 +22,9 @@ full_name = UserProfile.objects.get(user=self.real_user).name
 dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
+uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+request_path = request.get_full_path().lower()
+is_uai_course = any(course_key in request_path for course_key in uai_course_key_formats)
 %>
 
 <div class="nav-item hidden-mobile">
@@ -38,9 +41,14 @@ account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
         % if resume_block:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Accounts")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+        % if is_uai_course:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Accounts")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+        % endif
     </div>
 </div>

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -20,7 +20,7 @@ username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 full_name = UserProfile.objects.get(user=self.real_user).name
 dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
-learn_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
+mit_learn_dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
@@ -43,7 +43,7 @@ is_uai_course = any(course_key in request_path for course_key in uai_course_key_
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
         % endif
         % if is_uai_course:
-            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${learn_url}" role="menuitem">${_("Dashboard")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${mit_learn_dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
         % else:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -20,6 +20,7 @@ username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 full_name = UserProfile.objects.get(user=self.real_user).name
 dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
+learn_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
@@ -42,7 +43,7 @@ is_uai_course = any(course_key in request_path for course_key in uai_course_key_
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
         % endif
         % if is_uai_course:
-            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${learn_url}" role="menuitem">${_("Dashboard")}</a></div>
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
         % else:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -23,9 +23,9 @@ dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
 mit_learn_dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
-uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+uai_course_key_format = getattr(settings, "UAI_COURSE_KEY_FORMAT", "")
 request_path = request.get_full_path().lower()
-is_uai_course = any(course_key in request_path for course_key in uai_course_key_formats)
+is_uai_course = uai_course_key_format and uai_course_key_format in request_path
 %>
 
 <div class="nav-item hidden-mobile">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7355

### Description (What does it do?)
This PR enables the Catalog link to redirect to the Learn marketing app for UAI courses. This PR also updates the dropdown menu to display only dashboard and logout button for UAI courses.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Add the following to your `private.py` file:
   ```python
    MARKETING_SITE_BASE_URL = "http://mitxonline.mit.edu"
    MIT_LEARN_BASE_URL = "https://learn.mit.edu"
    UAI_COURSE_KEY_FORMATS = ["course-v1:uai_source", "course-v1:uai_hhc", "course-v1:uai_mit"]
   ```
- In Studio, create new courses using organization names that match the values in `UAI_COURSE_KEY_FORMATS`.

- Also, create a few courses with different organization names.

- Confirm the behavior of the **Catalog** button:
    - For courses with a Course Key containing any value from `UAI_COURSE_KEY_FORMATS`, it should redirect to `https://learn.mit.edu`.
    - For other courses, it should link to `http://mitxonline.mit.edu`.


### Additional Context
ol-infra PR to set the values: https://github.com/mitodl/ol-infrastructure/pull/3179

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
