### PR TITLE
feat: add mit_et in UAI courses

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -26,10 +26,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
-  uai_course_key_format = getattr(settings, "UAI_COURSE_KEY_FORMAT", "")
+  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", "")
   request_path = request.get_full_path().lower()
 
-  if uai_course_key_format and uai_course_key_format in request_path:
+  if uai_course_key_formats and any(key in request_path for key in uai_course_key_formats):
     catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MARKETING_SITE_BASE_URL", "#"))
   else:
     catalog_link = getattr(settings, "MARKETING_SITE_BASE_URL", "#")

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -23,9 +23,9 @@ dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
 mit_learn_dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
-uai_course_key_format = getattr(settings, "UAI_COURSE_KEY_FORMAT", "")
+uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", "")
 request_path = request.get_full_path().lower()
-is_uai_course = uai_course_key_format and uai_course_key_format in request_path
+is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
 %>
 
 <div class="nav-item hidden-mobile">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7355

### Description (What does it do?)
This PR must be merged after the merge of https://github.com/mitodl/ol-infrastructure/pull/3256
This PR adds MIT_ET in UAI courses.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Create a course in Studio with `MIT_ET` org
- In the private.py file, define
```python
MIT_LEARN_BASE_URL="https://learn.mit.edu"
UAI_COURSE_KEY_FORMATS = ["course-v1:uai_", "course-v1:mit_et"]
```
- Verify that the links on http://local.openedx.io:8000/courses/{course-id} point to learn website.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
