### PR TITLE
fix: change UAI courses dashboard url to mitxonline dashboard

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -20,7 +20,7 @@ username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 full_name = UserProfile.objects.get(user=self.real_user).name
 dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
-mit_learn_dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
+mit_learn_dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7672

### Description (What does it do?)
This PR changes back the dashboard url of UAI courses to mitxonline dashboard

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit a UAI course.
- Click the profile dropdown.
- Verify that the dashboard link redirects you to `{MARKETING_SITE_BASE_URL}/dashboard` and not `{MIT_LEARN_BASE_URL}/dashboard`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
