### PR TITLE
revert: 'fix: change UAI courses dashboard url to mitxonline dashboard'

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -20,7 +20,7 @@ username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 full_name = UserProfile.objects.get(user=self.real_user).name
 dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
-mit_learn_dashboard_url = urljoin(settings.MARKETING_SITE_BASE_URL, "dashboard")
+mit_learn_dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
 profile_url = urljoin(settings.MARKETING_SITE_BASE_URL, "profile")
 account_url = urljoin(settings.MARKETING_SITE_BASE_URL, "account-settings")
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8010

### Description (What does it do?)
This PR reverts the changes we made in https://github.com/mitodl/mitxonline-theme/pull/55. The dashboard link will now be pointing to the MIT Learn dashboard

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Follow https://mitodl.github.io/handbook/openedx/configuring_theme_in_edX.html to apply this theme in edx
- Ensure that you have set the following values in your `private.py`
```python
MIT_LEARN_BASE_URL="https://learn.mit.edu"
UAI_COURSE_KEY_FORMATS = ["course-v1:uai_", "course-v1:mit_et"]
```
- Verify that the dashboard link for UAI courses is pointing to `https://learn.mit.edu/dashboard`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
