### PR TITLE
fix: logo link issue

### DIFF
--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from urllib.parse import urljoin
 
 # App that handles subdomain specific branding
 from lms.djangoapps.branding import api as branding_api
@@ -19,9 +20,9 @@ from lms.djangoapps.branding import api as branding_api
   request_path = request.get_full_path().lower()
   is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
   if is_uai_course:
-    logo_destination_url = f"{getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')}/dashboard"
+    logo_destination_url = urljoin(f"{getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')}", "dashboard")
   else:
-    logo_destination_url = f"{getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')}/dashboard/"
+    logo_destination_url = urljoin(f"{getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')}", "dashboard")
 %>
 
 <h1 class="header-logo">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9461

### Description (What does it do?)
This PR fixes the incorrect logo link, which points to https://mitxonline.mit.edu//dashboard/ instead of https://mitxonline.mit.edu/dashboard/

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Click on the logo and verify for both UAI and non-UAI courses that the logo is pointing to correct url

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
