### PR TITLE
fix: settings title in dropdown to match MFE

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -424,6 +424,12 @@ body.view-in-course {
   vertical-align: middle !important;
 }
 
+@media (min-width: 992px) {
+    .global-header .nav-links .secondary .dropdown-user-menu .dropdown-item:not(:last-child) {
+        border: none !important;
+    }
+}
+
 @media (max-width: 991px) {
   .global-header {
     top: 0 !important;

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -45,7 +45,7 @@ if is_uai_course:
             % else:
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item show-in-mobile"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
-                <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Accounts")}</a></div>
+                <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Settings")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
             % endif
         </div>


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR updates the user dropdown by renaming the Accounts option to Settings, aligning it with the MFE dropdown settings title used in non-UAI courses. It also removes the bottom border from the dropdown items for improved visual consistency.

### Screenshots (if appropriate):
Before
<img width="359" height="202" alt="Screenshot 2026-01-23 at 4 17 08 PM" src="https://github.com/user-attachments/assets/ce0a5cc9-b987-4154-a23c-b0a7fce847a3" />

After
<img width="359" height="202" alt="Screenshot 2026-01-23 at 4 24 16 PM" src="https://github.com/user-attachments/assets/a4e2e6c9-e72e-430e-895c-a34d3970660c" />


MFE
<img width="359" height="202" alt="Screenshot 2026-01-23 at 4 18 49 PM" src="https://github.com/user-attachments/assets/f2cfba0b-2bba-4054-9914-9f8f43d4e356" />


### How can this be tested?
- Checkout this branch
- Visit a non-UAI course and verify that the user dropdown matches the After screenshot shown above.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
