### PR TITLE
feat: marked footer links for i18n

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -24,14 +24,14 @@
   icp_markup = u" | {icp}".format(icp=icp_license) if icp_license else ""
 
   footer_links = {
-    "about": {"url": None, "title": "About Us"},
-    "terms_of_service": {"url": None, "title": "Terms of Service"},
-    "accessibility_policy": {"url": None, "title": "Accessibility"},
-    "contact": {"url": None, "title": "Contact Us"}
+    "about": {"url": None, "title": _("About Us")},
+    "terms_of_service": {"url": None, "title": _("Terms of Service")},
+    "accessibility_policy": {"url": None, "title": _("Accessibility")},
+    "contact": {"url": None, "title": _("Contact Us")}
   }
 
   if not is_uai_course:
-      footer_links["help"] = {"url": settings.SUPPORT_SITE_LINK, "title": "Help"}
+      footer_links["help"] = {"url": settings.SUPPORT_SITE_LINK, "title": _("Help")}
 
   for link in footer['navigation_links'] + footer['legal_links']:
       url = link.get('url')


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9667

### Description (What does it do?)

Footer strings were not marked with i18n.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
