### PR TITLE
feat: override data_download.html to add the data platform certificate link

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,0 +1,168 @@
+<%page args="section_data" expression_filter="h"/>
+<%namespace name='static' file='/static_content.html'/>
+<%!
+from urllib.parse import quote
+
+from django.utils.translation import gettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<%
+  course_key = str(course.id)
+  course_key_encoded = quote(course_key, safe='')
+  data_platform_certificate_link = (
+    "https://bi.ol.mit.edu/superset/dashboard/14/?native_filters=(NATIVE_FILTER-Vz_eMSTIHKEPhUEzbKfeq:"
+    f"(extraFormData:(filters:!((col:'courserun_readable_id',op:IN,val:!('{course_key_encoded}')))),"
+    f"filterState:(value:!('{course_key_encoded}'))))"
+  )
+%>
+<div class="data-download-container action-type-container">
+  <div class="request-response-error msg msg-error copy" id="data-request-response-error"></div>
+
+
+  <br>
+  <p>${_("Click to display the grading configuration for the course. The grading configuration is the breakdown of graded subsections of the course (such as exams and problem sets), and can be changed on the 'Grading' page (under 'Settings') in Studio.")}</p>
+  <p><input type="button" name="dump-gradeconf" value="${_("Grading Configuration")}" data-endpoint="${ section_data['get_grading_config_url'] }"></p>
+
+  <div class="data-display-text" id="data-grade-config-text"></div>
+  <br>
+
+  <p>${_("The CSV of anonymized student IDs download has been relocated to the Reports section below.")}</p>
+
+ </div>
+
+%if settings.FEATURES.get('ENABLE_GRADE_DOWNLOADS'):
+  <div class="reports-download-container action-type-container">
+    <hr>
+    <h3 class="hd hd-3">${_("Reports")}</h3>
+
+    <p>${_("For large courses, generating some reports can take several hours. When report generation is complete, a link that includes the date and time of generation appears in the table below. These reports are generated in the background, meaning it is OK to navigate away from this page while your report is generating.")}</p>
+
+    <p>${_("Please be patient and do not click these buttons multiple times. Clicking these buttons multiple times will significantly slow the generation process.")}</p>
+
+    <p>${_("Click to generate a CSV file of all students enrolled in this course, along with profile information such as email address and username:")}</p>
+
+    <p><input type="button" name="list-profiles-csv" value="${_("Download profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] }" data-csv="true"></p>
+
+    <p>${_("Click to generate a CSV file that lists learners who can enroll in the course but have not yet done so.")}</p>
+
+    <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>
+
+    <p>${_("Click to generate a CSV file that lists learners who are enrolled in the course but have not yet activated their account.")}</p>
+
+    <p><input type="button" name="list-learners-not-activated-csv" value="${_("Download a CSV of learners who have not activated their account")}" data-endpoint="${ section_data['get_inactive_enrolled_students_url'] }" data-csv="true"></p>
+
+    <p>${_("Click to download a CSV of anonymized student IDs:")}</p>
+    <p><input type="button" name="list-anon-ids" value="${_("Get Student Anonymized IDs CSV")}" data-csv="true" class="csv" data-endpoint="${ section_data['get_anon_ids_url'] }" class="${'is-disabled' if disable_buttons else ''}" aria-disabled="${'true' if disable_buttons else 'false'}" ></p>
+
+    %if section_data['show_generate_proctored_exam_report_button']:
+      <p>${_("Click to generate a CSV file of all proctored exam results in this course.")}</p>
+      <p><input type="button" name="proctored-exam-results-report" value="${_("Generate Proctored Exam Results Report")}" data-endpoint="${ section_data['list_proctored_results_url'] }"/></p>
+    %endif
+
+    %if section_data['course_has_survey']:
+      <p>${_("Click to generate a CSV file of survey results for this course.")}</p>
+      <p><input type="button" name="survey-results-report" value="${_("Generate Survey Results Report")}" data-endpoint="${ section_data['course_survey_results_url'] }"/></p>
+    %endif
+
+    <p>${_("Select a problem to generate a CSV file that lists all student answers to the problem. You also select a section or chapter to include results of all problems in that section or chapter.")}</p>
+    <% max_entries = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT') %>
+    %if max_entries is not None:
+      <p>
+        <strong>${_("NOTE")}: </strong>
+        ${_("The generated report is limited to {max_entries} responses. If you expect more than {max_entries} "
+            "responses, try generating the report on a chapter-by-chapter, or problem-by-problem basis, or contact "
+            "your site administrator to increase the limit.").format(max_entries=max_entries)}
+      </p>
+    %endif
+
+    <div class="mb-15 problems">
+        ${static.renderReact(
+          component="ProblemBrowser",
+          id="react-problem-report",
+          props={
+            "courseId": course.id,
+            "excludeBlockTypes": ['html', 'video', 'discussion'],
+            "problemResponsesEndpoint": section_data['get_problem_responses_url'],
+            "taskStatusEndpoint": "/instructor_task_status",
+            "reportDownloadEndpoint": section_data['list_report_downloads_url'],
+            "ShowBtnUi": "true",
+          }
+        )}
+    </div>
+
+    <div class="issued_certificates">
+      <p>${_("Click to list certificates that are issued for this course:")}</p>
+      <p>
+        <a name="issued-certificates-list" class="light-button btn" href="${ data_platform_certificate_link }" target="_blank" rel="noopener noreferrer">
+          ${_("View Certificates Issued")}
+        </a>
+      </p>
+      <div class="data-display-table certificate-data-display-table" id="data-issued-certificates-table"></div>
+      <div class="issued-certificates-error request-response-error msg msg-error copy"></div>
+    </div>
+
+  % if not disable_buttons:
+    <p>${_("For smaller courses, click to list profile information for enrolled students directly on this page:")}</p>
+    <p><input type="button" name="list-profiles" value="${_("List enrolled students' profile information")}" data-endpoint="${ section_data['get_students_features_url'] }"></p>
+  %endif
+  <div class="data-display-table profile-data-display-table" id="data-student-profiles-table"></div>
+
+  %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
+    <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
+    <p>
+      <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
+      <input type="button" name="problem-grade-report" class="async-report-btn" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/>
+      <input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate ORA Data Report")}" data-endpoint="${ section_data['export_ora2_data_url'] }"/>
+      <input type="button" name="export-ora2-summary" class="async-report-btn" value="${_("Generate ORA Summary Report")}" data-endpoint="${ section_data['export_ora2_summary_url'] }"/>
+    </p>
+
+    <p>${_("Click to generate a ZIP file that contains all submission texts and attachments.")}</p>
+
+    <p><input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate Submission Files Archive")}" data-endpoint="${ section_data['export_ora2_submission_files_url'] }"/></p>
+
+  %endif
+
+    <div class="request-response msg msg-confirm copy" id="report-request-response"></div>
+    <div class="request-response-error msg msg-error copy" id="report-request-response-error"></div>
+    <br>
+
+    <h3 class="hd hd-3">${_("Reports Available for Download")}</h3>
+    <p>
+      ${_("The reports listed below are available for download, identified by UTC date and time of generation.")}
+    </p>
+
+  %if settings.FEATURES.get('ENABLE_ASYNC_ANSWER_DISTRIBUTION'):
+    <p>
+      ${_("The answer distribution report listed below is generated periodically by an automated background process. The report is cumulative, so answers submitted after the process starts are included in a subsequent report. The report is generated several times per day.")}
+    </p>
+  %endif
+
+    ## Translators: a table of URL links to report files appears after this sentence.
+    <p>
+        ${Text(_("{strong_start}Note{strong_end}: {ul_start}{li_start}To keep student data secure, you cannot save or email these links for direct access. Copies of links expire within 5 minutes.{li_end}{li_start}Report files are deleted 90 days after generation. If you will need access to old reports, download and store the files, in accordance with your institution's data security policies.{li_end}{ul_end}")).format(
+            strong_start=HTML("<strong>"),
+            strong_end=HTML("</strong>"),
+            ul_start=HTML("<ul>"),
+            ul_end=HTML("</ul>"),
+            li_start=HTML("<li>"),
+            li_end=HTML("</li>"),
+        )}
+    </p><br>
+
+    <div class="report-downloads-table" id="report-downloads-table" data-endpoint="${ section_data['list_report_downloads_url'] }" ></div>
+  </div>
+%endif
+
+%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+  <div class="running-tasks-container action-type-container">
+    <hr>
+    <h3 class="hd hd-3">${_("Pending Tasks")}</h3>
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
+  </div>
+%endif

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -104,7 +104,7 @@ from openedx.core.djangolib.markup import HTML, Text
             ${_("View Certificates Issued")}
           </span>
           <span class="copy-error" style="margin-left: 0.75em; color: #cb0712;">
-            ${_("No certificate data platform URL is configured. Please contact your administrator.")}
+            ${_("Certificates are not configured. Please contact your administrator.")}
           </span>
         % endif
       </p>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -9,12 +9,12 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%
-  course_key = str(course.id)
-  data_platform_certificate_base_url = getattr(settings, "DATAPLATFORM_CERTIFICATE_BASE_URL", "https://bi.ol.mit.edu/superset/dashboard/14/")
+  course_key_encoded = quote(str(course.id), safe='')
+  data_platform_certificate_base_url = getattr(settings, "DATAPLATFORM_CERTIFICATE_BASE_URL", "")
   data_platform_certificate_link = (
     f"{data_platform_certificate_base_url}?native_filters=(NATIVE_FILTER-Vz_eMSTIHKEPhUEzbKfeq:"
-    f"(extraFormData:(filters:!((col:'courserun_readable_id',op:IN,val:!('{course_key}')))),"
-    f"filterState:(value:!('{course_key}'))))"
+    f"(extraFormData:(filters:!((col:'courserun_readable_id',op:IN,val:!('{course_key_encoded}')))),"
+    f"filterState:(value:!('{course_key_encoded}'))))"
   )
 %>
 <div class="data-download-container action-type-container">
@@ -95,9 +95,18 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="issued_certificates">
       <p>${_("Click to list certificates that are issued for this course:")}</p>
       <p>
-        <a name="issued-certificates-list" class="light-button btn" href="${ data_platform_certificate_link }" target="_blank" rel="noopener noreferrer">
-          ${_("View Certificates Issued")}
-        </a>
+        % if data_platform_certificate_base_url:
+          <a name="issued-certificates-list" class="light-button btn" href="${ data_platform_certificate_link }" target="_blank" rel="noopener noreferrer">
+            ${_("View Certificates Issued")}
+          </a>
+        % else:
+          <span name="issued-certificates-list" class="light-button btn is-disabled" aria-disabled="true" style="opacity: 0.5; cursor: not-allowed;">
+            ${_("View Certificates Issued")}
+          </span>
+          <span class="copy-error" style="margin-left: 0.75em; color: #cb0712;">
+            ${_("No certificate data platform URL is configured. Please contact your administrator.")}
+          </span>
+        % endif
       </p>
       <div class="data-display-table certificate-data-display-table" id="data-issued-certificates-table"></div>
       <div class="issued-certificates-error request-response-error msg msg-error copy"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -3,17 +3,18 @@
 <%!
 from urllib.parse import quote
 
+from django.conf import settings
 from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%
   course_key = str(course.id)
-  course_key_encoded = quote(course_key, safe='')
+  data_platform_certificate_base_url = getattr(settings, "DATAPLATFORM_CERTIFICATE_BASE_URL", "https://bi.ol.mit.edu/superset/dashboard/14/")
   data_platform_certificate_link = (
-    "https://bi.ol.mit.edu/superset/dashboard/14/?native_filters=(NATIVE_FILTER-Vz_eMSTIHKEPhUEzbKfeq:"
-    f"(extraFormData:(filters:!((col:'courserun_readable_id',op:IN,val:!('{course_key_encoded}')))),"
-    f"filterState:(value:!('{course_key_encoded}'))))"
+    f"{data_platform_certificate_base_url}?native_filters=(NATIVE_FILTER-Vz_eMSTIHKEPhUEzbKfeq:"
+    f"(extraFormData:(filters:!((col:'courserun_readable_id',op:IN,val:!('{course_key}')))),"
+    f"filterState:(value:!('{course_key}'))))"
   )
 %>
 <div class="data-download-container action-type-container">


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9759

### Description (What does it do?)
This PR overrides the data_download.html to add the data platform certificate link

### Screenshots (if appropriate):
<img width="1790" height="938" alt="Screenshot 2026-02-03 at 12 08 08 PM" src="https://github.com/user-attachments/assets/4266d612-aedb-473d-8073-fc8f65fdad8e" />

If DATAPLATFORM_CERTIFICATE_BASE_URL is not set
<img width="1512" height="828" alt="Screenshot 2026-02-24 at 12 32 13 PM" src="https://github.com/user-attachments/assets/2bd6f226-251f-4d4f-a582-9db67cfc4a6f" />


### How can this be tested?
- Apply the theme in your local edX-platform instance using https://mitodl.github.io/handbook/openedx/configuring_theme_in_edX.html
- Open a course in LMS, visit the instructor dashboard, and then Data Download
- Set the `DATAPLATFORM_CERTIFICATE_BASE_URL` in your private.py and verify that the button in the SS above is enabled and links to the correct URL.
- Remove `DATAPLATFORM_CERTIFICATE_BASE_URL` from private.py and verify that the button is not disabled and shows an error message as shown in the SS above

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
