### PR TITLE
feat: updated css for staff buttons

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -385,9 +385,9 @@ body.view-in-course {
    }
   }
   .header-logo a{
-    display: flex; 
-    align-items: center; 
-    justify-content: center; 
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-left: 30px !important;
   }
   .dropdown-user-menu {
@@ -638,4 +638,13 @@ body.view-in-course {
   .mobile-nav-item {
     font-size: 18px !important;
 }
+}
+@media (min-width: 768px) {
+  .wrap-instructor-info {
+    display: flex !important;
+    gap: 10px;
+  }
+}
+.wrap-instructor-info .instructor-info-action {
+  margin-left: 0px !important;
 }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/open-edx-plugins/pull/722

### Description (What does it do?)
Staff buttons position was getting effected due to AskTim Button. Change the css properties to adjust the Staff buttons better.

### Screenshots (if appropriate):
For Staff view:
<img width="1505" height="961" alt="Screenshot 2026-02-16 at 6 49 17 PM" src="https://github.com/user-attachments/assets/6585d377-cb66-4798-be18-7755052703cc" />

For Learner View:
<img width="1378" height="1002" alt="Screenshot 2026-02-16 at 6 49 44 PM" src="https://github.com/user-attachments/assets/669b5a2a-dcd8-47d9-bc5e-54a26b7808da" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
