### PR TITLE
feat: use learn URLs by default in header

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -5,7 +5,8 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from urllib.parse import urljoin
+import re
+from urllib.parse import unquote, urljoin
 
 from django.conf import settings
 from django.urls import reverse
@@ -22,19 +23,23 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   self.real_user = getattr(user, 'real_user', user)
 
-  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
   uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
-  request_path = request.get_full_path().lower()
-  dashboard_url = urljoin(getattr(settings,'MITXONLINE_BASE_URL',"https://mitxonline.mit.edu"), "dashboard")
+  request_path = unquote(request.get_full_path()).lower()
+  is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
   is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
 
-  if is_uai_course:
-    catalog_link = getattr(settings, "MIT_LEARN_BASE_URL", getattr(settings, "MITXONLINE_BASE_URL", "#"))
-    support_link = getattr(settings, "MIT_LEARN_SUPPORT_SITE_LINK", "mailto:mitlearn-support@mit.edu")
-    dashboard_url = urljoin(settings.MIT_LEARN_BASE_URL, "dashboard")
+  mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
+  mitlearn_base_url = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
+  use_mitxonline_links = is_course_key_in_path and not is_uai_course
+  if use_mitxonline_links:
+    support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+    catalog_link = mitxonline_base_url
+    dashboard_url = urljoin(mitxonline_base_url, 'dashboard')
   else:
-    catalog_link = getattr(settings, "MITXONLINE_BASE_URL", "https://mitxonline.mit.edu")
+    catalog_link = mitlearn_base_url
+    support_link = getattr(settings, 'MIT_LEARN_SUPPORT_SITE_LINK', 'mailto:mitlearn-support@mit.edu')
+    dashboard_url = urljoin(mitlearn_base_url, 'dashboard')
 
   if support_link:
     help_link = support_link

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -32,8 +32,8 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
   mitlearn_base_url = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
-  use_mitxonline_links = is_course_key_in_path and not is_uai_course
-  if use_mitxonline_links:
+  is_mitxonline_course = is_course_key_in_path and not is_uai_course
+  if is_mitxonline_course:
     support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
     catalog_link = mitxonline_base_url
     dashboard_url = urljoin(mitxonline_base_url, 'dashboard')

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -25,8 +25,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   doc_link = get_online_help_info(online_help_token)['doc_url']
   uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
+  course_key_regex = getattr(settings, "COURSE_KEY_REGEX", '(?:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)')
   request_path = unquote(request.get_full_path()).lower()
-  is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
+  is_course_key_in_path = bool(re.search(course_key_regex, request_path, flags=re.IGNORECASE))
   is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
 
   mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -25,9 +25,9 @@ from lms.djangoapps.branding import api as branding_api
 
   mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
   mitlearn_base_url = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
-  use_mitxonline_links = is_course_key_in_path and not is_uai_course
+  is_mitxonline_course = is_course_key_in_path and not is_uai_course
 
-  if use_mitxonline_links:
+  if is_mitxonline_course:
     logo_destination_url = urljoin(f"{getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')}", "dashboard")
   else:
     logo_destination_url = urljoin(f"{getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')}", "dashboard")

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -19,7 +19,8 @@ from lms.djangoapps.branding import api as branding_api
 <%
   uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
   request_path = unquote(request.get_full_path()).lower()
-  is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
+  course_key_regex = getattr(settings, "COURSE_KEY_REGEX", '(?:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)')
+  is_course_key_in_path = bool(re.search(course_key_regex, request_path, flags=re.IGNORECASE))
   is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
 
   mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -4,12 +4,13 @@
 
 <%namespace name='static' file='../static_content.html'/>
 <%!
+import re
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from urllib.parse import urljoin
+from urllib.parse import unquote, urljoin
 
 # App that handles subdomain specific branding
 from lms.djangoapps.branding import api as branding_api
@@ -17,12 +18,18 @@ from lms.djangoapps.branding import api as branding_api
 
 <%
   uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
-  request_path = request.get_full_path().lower()
+  request_path = unquote(request.get_full_path()).lower()
+  is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
   is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
-  if is_uai_course:
-    logo_destination_url = urljoin(f"{getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')}", "dashboard")
-  else:
+
+  mitxonline_base_url = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
+  mitlearn_base_url = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
+  use_mitxonline_links = is_course_key_in_path and not is_uai_course
+
+  if use_mitxonline_links:
     logo_destination_url = urljoin(f"{getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')}", "dashboard")
+  else:
+    logo_destination_url = urljoin(f"{getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')}", "dashboard")
 %>
 
 <h1 class="header-logo">

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -23,7 +23,8 @@ account_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonli
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
 request_path = unquote(request.get_full_path()).lower()
 is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
-is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
+course_key_regex = getattr(settings, "COURSE_KEY_REGEX", '(?:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)')
+is_course_key_in_path = bool(re.search(course_key_regex, request_path, flags=re.IGNORECASE))
 use_mitxonline_links = is_course_key_in_path and not is_uai_course
 
 if use_mitxonline_links:

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -3,7 +3,8 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-from urllib.parse import urljoin
+import re
+from urllib.parse import unquote, urljoin
 
 from django.conf import settings
 from django.urls import reverse
@@ -20,11 +21,15 @@ full_name = UserProfile.objects.get(user=self.real_user).name
 profile_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu'), "profile")
 account_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu'), "account-settings")
 uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
-request_path = request.get_full_path().lower()
+request_path = unquote(request.get_full_path()).lower()
 is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
-dashboard_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu'), "dashboard")
-if is_uai_course:
-    dashboard_url = urljoin(getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu'), "dashboard")
+is_course_key_in_path = bool(re.search(r"course-v1:[a-z0-9._-]+\+[a-z0-9._-]+\+[a-z0-9._-]+", request_path, flags=re.IGNORECASE))
+use_mitxonline_links = is_course_key_in_path and not is_uai_course
+
+if use_mitxonline_links:
+    dashboard_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu'), 'dashboard')
+else:
+    dashboard_url = urljoin(getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu'), 'dashboard')
 %>
 
 <div class="nav-item nav-item-dropdown" tabindex="-1">
@@ -39,13 +44,13 @@ if is_uai_course:
             </div>
         </div>
         <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
-            % if is_uai_course:
-                <div class="mobile-nav-item dropdown-item dropdown-nav-item show-in-mobile"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
-                <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
-            % else:
+            % if use_mitxonline_links:
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item show-in-mobile"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Settings")}</a></div>
+                <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+            % else:
+                <div class="mobile-nav-item dropdown-item dropdown-nav-item show-in-mobile"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
             % endif
         </div>

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -25,9 +25,9 @@ request_path = unquote(request.get_full_path()).lower()
 is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
 course_key_regex = getattr(settings, "COURSE_KEY_REGEX", '(?:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)')
 is_course_key_in_path = bool(re.search(course_key_regex, request_path, flags=re.IGNORECASE))
-use_mitxonline_links = is_course_key_in_path and not is_uai_course
+is_mitxonline_course = is_course_key_in_path and not is_uai_course
 
-if use_mitxonline_links:
+if is_mitxonline_course:
     dashboard_url = urljoin(getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu'), 'dashboard')
 else:
     dashboard_url = urljoin(getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu'), 'dashboard')
@@ -45,7 +45,7 @@ else:
             </div>
         </div>
         <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
-            % if use_mitxonline_links:
+            % if is_mitxonline_course:
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item show-in-mobile"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
                 <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${account_url}" role="menuitem">${_("Settings")}</a></div>

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
+import re
 from urllib.parse import urljoin
 from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
@@ -24,10 +25,13 @@ from django.conf import settings
                     uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
                     request_path = request.get_full_path().lower()
                     is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
-                    if is_uai_course:
-                        homepage_link = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
-                    else:
+                    course_key_regex = getattr(settings, "COURSE_KEY_REGEX", '(?:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)')
+                    is_course_key_in_path = bool(re.search(course_key_regex, request_path, flags=re.IGNORECASE))
+                    is_mitxonline_course = is_course_key_in_path and not is_uai_course
+                    if is_mitxonline_course:
                         homepage_link = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
+                    else:
+                        homepage_link = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
                 %>
                 ${_('The page that you were looking for was not found.')}
                 ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -32,13 +32,12 @@ from django.conf import settings
                         homepage_link = getattr(settings, 'MITXONLINE_BASE_URL', 'https://mitxonline.mit.edu')
                     else:
                         homepage_link = getattr(settings, 'MIT_LEARN_BASE_URL', 'https://learn.mit.edu')
+                    support_link = getattr(settings, 'MIT_LEARN_SUPPORT_SITE_LINK', 'mailto:mitlearn-support@mit.edu')
                 %>
                 ${_('The page that you were looking for was not found.')}
                 ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
                   homepage=HTML(f'<a href="{homepage_link}">homepage</a>'),
-                  email=HTML('<a href="{address}">contact us</a>').format(
-                    address=Text(marketing_link('CONTACT'))
-                  )
+                  email=HTML(f'<a href="{support_link}">contact us</a>')
                 )}
                 % endif
             </%block>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9834

### Description (What does it do?)
This PR updates the header logic to check for the presence of a course key in the header, and if it exists and is not a UAI course, link to mitxonline; otherwise, default to MIT Learn.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit a legacy page of a UAI course and verify the links in the header point to learn
- Visit a legacy page of a non-UAI course and verify the links in the header point to mitxonline
- Visit any page without a course key in the url like dashboard, 404 error, etc. Verify that the links in the header point to learn

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
