### PR TITLE
fix: certificate link not opening in firefox

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -96,7 +96,7 @@ from openedx.core.djangolib.markup import HTML, Text
       <p>${_("Click to list certificates that are issued for this course:")}</p>
       <p>
         % if data_platform_certificate_base_url:
-          <a name="issued-certificates-list" class="light-button btn" href="${ data_platform_certificate_link }" target="_blank" rel="noopener noreferrer">
+          <a name="issued-certificates-list" class="light-button btn" href="${ data_platform_certificate_link | n }" target="_blank" rel="noopener">
             ${_("View Certificates Issued")}
           </a>
         % else:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9759

### Description (What does it do?)
Clicking the "View Certificates Issued" button on the Instructor Dashboard's Data Download tab works fine in Chrome and Safari but fails in Firefox — the new tab briefly flashes open and then immediately closes.

The link had rel="noopener noreferrer" on it. The noreferrer attribute tells the browser not to send the Referer header with the request. Firefox enforces this more strictly than Chrome and Safari.

The target site (Superset BI dashboard) relies on the Referer header as part of its session/authentication validation. When Firefox strips the Referer header, Superset sees the request as unauthorized and rejects it — causing the page to fail to load and the tab to close.

Chrome and Safari are more relaxed about when they actually strip the Referer header, which is why the link worked in those browsers.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Open http://local.openedx.io:8000/courses/course-v1:edX+E2E-101+course/instructor#view-data_download in firefox
- Verify that when clicking the "View Certificates Issued" link, it redirects to the page without any issue

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
