### PR TITLE
fix: change contact link to point to learn support

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -12,9 +12,6 @@
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <%
-  uai_course_key_formats = getattr(settings, "UAI_COURSE_KEY_FORMATS", [])
-  request_path = request.get_full_path().lower()
-  is_uai_course = uai_course_key_formats and any(key in request_path for key in uai_course_key_formats)
   platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
   footer = get_footer(is_secure=request.is_secure())
   footer['copyright'] = _(u"\u00A9 {year} Massachusetts Institute of Technology").format(year=datetime.now().year)

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -27,11 +27,9 @@
     "about": {"url": None, "title": _("About Us")},
     "terms_of_service": {"url": None, "title": _("Terms of Service")},
     "accessibility_policy": {"url": None, "title": _("Accessibility")},
-    "contact": {"url": None, "title": _("Contact Us")}
   }
 
-  if not is_uai_course:
-      footer_links["help"] = {"url": settings.SUPPORT_SITE_LINK, "title": _("Help")}
+  footer_links["help"] = {"url": settings.MIT_LEARN_SUPPORT_SITE_LINK, "title": _("Help")}
 
   for link in footer['navigation_links'] + footer['legal_links']:
       url = link.get('url')


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10933

### Description (What does it do?)
This PR changes the contact link in the footer to `Help` link pointing to https://support.learn.mit.edu

### Screenshots (if appropriate):

<img width="1508" height="836" alt="Screenshot 2026-04-27 at 4 17 53 PM" src="https://github.com/user-attachments/assets/faec4f6b-4d4a-4f23-8caa-f1a98ced1c9a" />

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Verify that the footer has the Help link pointing to https://support.learn.mit.edu/

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
