### PR TITLE
fix: remove wrap-instructor-info css to correctly display staff buttons on Show Answer

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -639,15 +639,7 @@ body.view-in-course {
     font-size: 18px !important;
 }
 }
-@media (min-width: 768px) {
-  .wrap-instructor-info {
-    display: flex !important;
-    flex-wrap: wrap;
-    gap: 10px;
-    width: 100%;
-    flex-shrink: 0;
-  }
-}
+
 .wrap-instructor-info .instructor-info-action {
   margin-left: 0px !important;
 }

--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -642,7 +642,10 @@ body.view-in-course {
 @media (min-width: 768px) {
   .wrap-instructor-info {
     display: flex !important;
+    flex-wrap: wrap;
     gap: 10px;
+    width: 100%;
+    flex-shrink: 0;
   }
 }
 .wrap-instructor-info .instructor-info-action {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11304

### Description (What does it do?)

When a learner clicks "Show Answer" on a problem, the revealed answer content expands within a flex parent container, causing `.wrap-instructor-info` (Staff Debug Info / Submission History buttons) to collapse to zero width. I first added the [fix](https://github.com/mitodl/mitxonline-theme/pull/85/commits/d0abda5b085eeb238ac2ec22830abd524f1059d4) here, but following Peter's recommendation, moving it to https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_chat/ol_openedx_chat/static/css/ai_chat.css. Fix PR: https://github.com/mitodl/open-edx-plugins/pull/796

### Screenshots (if appropriate):
Before
<img width="829" height="795" alt="Screenshot 2026-05-18 at 5 33 28 PM" src="https://github.com/user-attachments/assets/e89052d5-f4f1-42b6-b715-db5e0342eab1" />

After
<img width="829" height="795" alt="Screenshot 2026-05-18 at 5 31 38 PM" src="https://github.com/user-attachments/assets/42d4abc4-5388-40ef-983b-24ee0b75752b" />

### How can this be tested?
- Enabling the AskTim button is not required for testing. The issue can be reproduced without it.
- Install ol-openedx-chat from [this branch](https://github.com/mitodl/open-edx-plugins/tree/anas/fix-staff-btns-css).
- Enable the theme, and open a problem.
- Click the "Show answer" button.
- Verify that it doesn't break the styling of Staff Debug Info / Submission History buttons.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
